### PR TITLE
Modified makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,8 @@ run:
 	godot {{godot_project_path_arg}} -d
 
 watch:
-	cargo watch -x build -s 'mv ./target/debug/*.* ./lib'
+	cargo watch -x build -s 'mv ./target/debug/*.* ./lib' &
+	godot {{godot_project_path_arg}} -d
 
 shell:
 	nix-shell --pure

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,13 @@ edit:
 	godot {{godot_project_path_arg}} -e &
 
 run:
-	make build-x86_64-unknown-linux-gnu-debug
+	# make build-x86_64-unknown-linux-gnu-debug
+	cargo build
+	mv ./target/debug/*.* ./lib
 	godot {{godot_project_path_arg}} -d
+
+watch:
+	cargo watch -x build -s 'mv ./target/debug/*.* ./lib'
 
 shell:
 	nix-shell --pure


### PR DESCRIPTION
make run - now just runs cargo build and copies
any targets to the ./lib folder. This is kind of a dirty way of getting this to work on MacOS and should work with any other OS.

make watch - now uses cargo-watch to watch the
project, build, and copy the target - same as make run.